### PR TITLE
fix resetting levels during level end animation

### DIFF
--- a/src/UILayer.cpp
+++ b/src/UILayer.cpp
@@ -144,12 +144,12 @@ struct $modify(UILayer) {
                 }
             });
             this->defineKeybind("robtop.geometry-dash/restart-level", [=](bool down) {
-                if (down && this->isCurrentPlayLayer() && !this->isPaused()) {
+                if (down && this->isCurrentPlayLayer() && !this->isPaused() && PlayLayer::get()->canPauseGame()) {
                     PlayLayer::get()->resetLevel();
                 }
             });
             this->defineKeybind("robtop.geometry-dash/full-restart-level", [=](bool down) {
-                if (down && this->isCurrentPlayLayer() && !this->isPaused()) {
+                if (down && this->isCurrentPlayLayer() && !this->isPaused() && PlayLayer::get()->canPauseGame()) {
                     PlayLayer::get()->fullReset();
                 }
             });


### PR DESCRIPTION
fixes weird behavior if you try to press the Restart Level keybind during level end animation (it now should be impossible to do so.)

note that this requires https://github.com/geode-sdk/bindings/pull/158 to be merged first in order to compile