### PR TITLE
Modifier Repeat Fix

### DIFF
--- a/src/Keybinds.cpp
+++ b/src/Keybinds.cpp
@@ -1,7 +1,8 @@
 #include "../include/Keybinds.hpp"
-#include "Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h"
-#include "Geode/cocos/sprite_nodes/CCSprite.h"
-#include "Geode/loader/Event.hpp"
+
+#include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h>
+#include <Geode/cocos/sprite_nodes/CCSprite.h>
+#include <Geode/loader/Event.hpp>
 #include <Geode/utils/ranges.hpp>
 #include <Geode/utils/string.hpp>
 #include <Geode/loader/ModEvent.hpp>
@@ -759,7 +760,7 @@ ListenerResult BindManager::onDispatch(PressBindEvent* event) {
                 if (!m_held.contains(action)) {
                     m_held.insert(action);
                     inserted = true;
-                }
+                } 
                 if (auto options = this->getRepeatOptionsFor(action)) {
                     if (options.value().enabled && ranges::contains(m_repeating, [=](auto const& p) { return p.first == action; })) {
                         return ListenerResult::Stop;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,11 +69,16 @@ class $modify(CCKeyboardDispatcher) {
 					return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, p2);
 				}
 				std::unordered_set<Modifier> modifiersToToggle = this->getModifiersToToggle(key, down);
+				bool ok = true;
 				for (auto& held : s_held) {
+					if (!ok) {
+						break;
+					}
 					for (Modifier modifiers : modifiersToToggle) {
 						Keybind* bind = Keybind::create(held, modifiers);
 						if (bind && PressBindEvent(bind, down).post() == ListenerResult::Stop) {
 							// we want to pass modifiers onwards to the original
+							ok = false;
 							break;
 						}
 					}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,11 @@
 #include <Geode/modify/Modify.hpp>
 #include <Geode/loader/SettingNode.hpp>
 #include <Geode/loader/Setting.hpp>
+#include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDelegate.h>
+#include <Geode/cocos/robtop/keyboard_dispatcher/CCKeyboardDispatcher.h>
+
+#include <unordered_set>
+
 #include "../include/Keybinds.hpp"
 #include "KeybindsLayer.hpp"
 
@@ -59,28 +64,90 @@ class $modify(CCKeyboardDispatcher) {
 			}
 			// dispatch release events for Modifier + Key combos
 			else {
-				Modifier modifiers = Modifier::None;
-				if (m_bControlPressed || key == KEY_Control) {
-					modifiers |= Modifier::Control;
+				// If no actual key was being held, just modifiers
+				if (s_held.empty() && !down) {
+					return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, p2);
 				}
-				if (m_bAltPressed || key == KEY_Alt) {
-					modifiers |= Modifier::Alt;
-				}
-				if (m_bCommandPressed /* todo */) {
-					modifiers |= Modifier::Command;
-				}
-				if (m_bShiftPressed || key == KEY_Shift) {
-					modifiers |= Modifier::Shift;
-				}
+				std::unordered_set<Modifier> modifiersToToggle = this->getModifiersToToggle(key, down);
 				for (auto& held : s_held) {
-					if (PressBindEvent(Keybind::create(held, modifiers), down).post() == ListenerResult::Stop) {
-						// we want to pass modifiers onwards to the original
-						break;
+					for (Modifier modifiers : modifiersToToggle) {
+						Keybind* bind = Keybind::create(held, modifiers);
+						if (bind && PressBindEvent(bind, down).post() == ListenerResult::Stop) {
+							// we want to pass modifiers onwards to the original
+							break;
+						}
 					}
 				}
 			}
 		}
 		return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, p2);
+	}
+
+	/**
+	 * Get the modifiers that need to be verified for keybinds. If a modifier is being released we need to check all combinations that use that modifier.
+	 * @param key the modifier that was pressed
+	 * @param down if the modifier was pressed or released
+	 * @returns a list of modifiers that need to be checked for keybinds
+	*/
+	std::unordered_set<Modifier> getModifiersToToggle(enumKeyCodes key, bool down) {
+		std::unordered_set<Modifier> modifiersToToggle = {};
+		if (!keyIsModifier(key)) {
+			return modifiersToToggle;	
+		}
+		if (down) {
+			Modifier modifiers = Modifier::None;
+			if (m_bControlPressed || key == KEY_Control) {
+				modifiers |= Modifier::Control;
+			}
+			if (m_bAltPressed || key == KEY_Alt) {
+				modifiers |= Modifier::Alt;
+			}
+			if (m_bCommandPressed /* todo */) {
+				modifiers |= Modifier::Command;
+			}
+			if (m_bShiftPressed || key == KEY_Shift) {
+				modifiers |= Modifier::Shift;
+			}
+			modifiersToToggle.insert(modifiers);
+		} else {
+			/**
+			 * We need to disable all combinations that use the "disabled" modifier key.
+			 * Left/Right variations don't seem to be used by GD.
+			 * Adding them just to be sure.
+			*/
+			switch (key) {
+				case KEY_LeftControl:
+				case KEY_RightContol:
+				case KEY_Control: {
+					modifiersToToggle.insert(Modifier::Control);
+					modifiersToToggle.insert(Modifier::Control | Modifier::Alt);
+					modifiersToToggle.insert(Modifier::Control | Modifier::Shift);
+					modifiersToToggle.insert(Modifier::Control | Modifier::Shift | Modifier::Alt);
+					break;
+				}
+				case KEY_LeftShift:
+				case KEY_RightShift:
+				case KEY_Shift: {
+					modifiersToToggle.insert(Modifier::Shift);
+					modifiersToToggle.insert(Modifier::Shift | Modifier::Alt);
+					modifiersToToggle.insert(Modifier::Control | Modifier::Shift);
+					modifiersToToggle.insert(Modifier::Control | Modifier::Shift | Modifier::Alt);
+					break;
+				}
+				case KEY_Alt: {
+					modifiersToToggle.insert(Modifier::Alt);
+					modifiersToToggle.insert(Modifier::Alt | Modifier::Control);
+					modifiersToToggle.insert(Modifier::Alt | Modifier::Shift);
+					modifiersToToggle.insert(Modifier::Control | Modifier::Shift | Modifier::Alt);
+					break;
+				}
+				default: {
+					// This shouldn't happen
+					break;
+				}
+			}
+		}
+		return modifiersToToggle;
 	}
 };
 


### PR DESCRIPTION
I noticed JamAttack was complaining about some weird functionality with the undo keybind while using Custom Keybinds in some of his videos. Decided to snoop around a little. Turns out modifier releases weren't being checked properly.

Here's a simple example to check on the latest version:
 * Enter the editor
 * Place some objects around
 * Hold "Z"
 * Hold "CTRL" (this will start repeating undo)
 * Hold "Shift" (this will start repeating redo)
 * Release all keys at once

If reproduced correctly, only the "redo" keybind should be "released", while the "undo" command will remain in a repeat loop, until the editor is exited.

My proposed fix is marking every single keybind that uses the modifier as "released" when releasing the modifier itself. Implementation might be a little ugly, but it works, and I don't think any fancy algorithm is needed for just making some modifier combinations.

## TODOs:

[ ] Figure out how MacOS uses "Command" as a modifier and how does it interact with other modifiers