### PR TITLE
Shift hold fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,7 +93,7 @@ class $modify(CCKeyboardDispatcher) {
 			// dispatch release events for Modifier + Key combos
 			else {
 				// If no actual key was being held, just modifiers
-				if(!down) {
+				if (!down) {
 					// Stop repeats here, resolves repeat issue when keys and modifiers are pressed in reverse
 					BindManager::get()->stopAllRepeats();
 					if (s_held.empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,8 +21,7 @@ using namespace keybinds;
 
 class $modify(CCEGLView){
 
-	void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods){
-
+	void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
 		enumKeyCodes keycode = enumKeyCodes::KEY_Unknown;
 
 		switch(key){
@@ -37,7 +36,6 @@ class $modify(CCEGLView){
 		if(keycode != enumKeyCodes::KEY_Unknown){
 			CCKeyboardDispatcher::get()->dispatchKeyboardMSG(keycode, action >= 1, action == 2);
 		}
-
 		CCEGLView::onGLFWKeyCallback(window, key, scancode, action, mods);
 	}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,9 +89,13 @@ class $modify(CCKeyboardDispatcher) {
 			// dispatch release events for Modifier + Key combos
 			else {
 				// If no actual key was being held, just modifiers
-				if (s_held.empty() && !down) {
-					return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, p2);
+				if(!down){
+					BindManager::get()->stopAllRepeats();
+					if (s_held.empty()) {
+						return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, p2);
+					}
 				}
+
 				std::unordered_set<Modifier> modifiersToToggle = this->getModifiersToToggle(key, down);
 				bool ok = true;
 				for (auto& held : s_held) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Geode/modify/CCKeyboardDispatcher.hpp>
 #include <Geode/modify/MoreOptionsLayer.hpp>
+#include <Geode/modify/CCEGLView.hpp>
 #include <Geode/binding/AppDelegate.hpp>
 #include <Geode/binding/PlatformToolbox.hpp>
 #include <Geode/binding/ButtonSprite.hpp>
@@ -17,6 +18,29 @@
 
 using namespace geode::prelude;
 using namespace keybinds;
+
+class $modify(CCEGLView){
+
+	void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods){
+
+		enumKeyCodes keycode = enumKeyCodes::KEY_Unknown;
+
+		switch(key){
+			case GLFW_KEY_LEFT_SHIFT:
+				keycode = enumKeyCodes::KEY_LeftShift;
+				break;
+			case GLFW_KEY_RIGHT_SHIFT:
+				keycode = enumKeyCodes::KEY_RightShift;
+				break;
+		}
+
+		if(keycode != enumKeyCodes::KEY_Unknown){
+			CCKeyboardDispatcher::get()->dispatchKeyboardMSG(keycode, action >= 1, action == 2);
+		}
+
+		CCEGLView::onGLFWKeyCallback(window, key, scancode, action, mods);
+	}
+};
 
 class $modify(CCKeyboardDispatcher) {
 	static inline std::unordered_set<enumKeyCodes> s_held {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ class $modify(CCEGLView){
 	void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
 		enumKeyCodes keycode = enumKeyCodes::KEY_Unknown;
 
-		switch(key){
+		switch (key) {
 			case GLFW_KEY_LEFT_SHIFT:
 				keycode = enumKeyCodes::KEY_LeftShift;
 				break;
@@ -37,7 +37,7 @@ class $modify(CCEGLView){
 				break;
 		}
 
-		if(keycode != enumKeyCodes::KEY_Unknown){
+		if (keycode != enumKeyCodes::KEY_Unknown) {
 			CCKeyboardDispatcher::get()->dispatchKeyboardMSG(keycode, action >= 1, action == 2);
 		}
 		CCEGLView::onGLFWKeyCallback(window, key, scancode, action, mods);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,10 @@ using namespace keybinds;
 
 class $modify(CCEGLView){
 
+	/**
+	* GD does not pass shift into dispatchKeyboardMSG, causing the modifier to break when holding.
+	* We need to manually pass in shift from onGLFWKeyCallback to resolve this bug.
+	*/
 	void onGLFWKeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
 		enumKeyCodes keycode = enumKeyCodes::KEY_Unknown;
 
@@ -89,13 +93,13 @@ class $modify(CCKeyboardDispatcher) {
 			// dispatch release events for Modifier + Key combos
 			else {
 				// If no actual key was being held, just modifiers
-				if(!down){
+				if(!down) {
+					// Stop repeats here, resolves repeat issue when keys and modifiers are pressed in reverse
 					BindManager::get()->stopAllRepeats();
 					if (s_held.empty()) {
 						return CCKeyboardDispatcher::dispatchKeyboardMSG(key, down, p2);
 					}
 				}
-
 				std::unordered_set<Modifier> modifiersToToggle = this->getModifiersToToggle(key, down);
 				bool ok = true;
 				for (auto& held : s_held) {


### PR DESCRIPTION
The shift key is normally not passed through to CCKeyboardDispatcher::dispatchKeyboardMSG, this means the modifier is never properly handled, allowing for an annoying bug where releasing shift while holding another key causes the original action to keep repeating after the key is released. This PR fixes this issue by passing shift inputs into dispatchKeyboardMSG. 