### PR TITLE
Add Mac support and fix CommentType error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
         - name: Windows
           os: windows-latest
           
-        # - name: macOS
-        #   os: macos-latest
+        - name: macOS
+          os: macos-latest
 
         - name: Android32
           os: ubuntu-latest

--- a/mod.json
+++ b/mod.json
@@ -2,7 +2,8 @@
 	"geode": "4.0.1",
 	"gd": {
 		"win": "2.2074",
-		"android": "2.2074"
+		"android": "2.2074",
+		"mac": "2.2074"
 	},
 	"version": "v1.10.1",
 	"id": "geode.custom-keybinds",

--- a/src/macos.mm
+++ b/src/macos.mm
@@ -1,9 +1,11 @@
-#include <Geode/Loader.hpp>
-#include <Geode/Utils.hpp>
+#include <Geode/platform/platform.hpp>
 
 #if defined(GEODE_IS_MACOS)
 #import <Cocoa/Cocoa.h>
 #include <objc/runtime.h>
+
+#include <Geode/Loader.hpp>
+#include <Geode/Utils.hpp>
 
 using namespace geode::prelude;
 


### PR DESCRIPTION
This adds support for Mac, allowing many other mods like BetterEdit and ClickBetweenFrames to become available for Mac users.