### PR TITLE
macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,8 @@ jobs:
         - name: Windows
           os: windows-latest
           
-        # - name: macOS
-        #   os: macos-latest
+        - name: macOS
+          os: macos-latest
 
         - name: Android32
           os: ubuntu-latest

--- a/mod.json
+++ b/mod.json
@@ -1,8 +1,9 @@
 {
-	"geode": "4.0.1",
+	"geode": "4.2.0",
 	"gd": {
 		"win": "2.2074",
-		"android": "2.2074"
+		"android": "2.2074",
+		"mac": "2.2074"
 	},
 	"version": "v1.10.1",
 	"id": "geode.custom-keybinds",
@@ -27,8 +28,6 @@
 			"include/*.hpp"
 		]
 	},
-	"dependencies": [],
-	"incompatibilities": [],
 	"settings": {
 		"open-menu": {
 			"type": "custom:open-menu"

--- a/src/EditorUI.cpp
+++ b/src/EditorUI.cpp
@@ -388,14 +388,17 @@ $execute {
         "robtop.geometry-dash/undo",
         "Undo",
         "Undo Last Action",
-        { Keybind::create(KEY_Z, Modifier::PlatformControl) },
+        { Keybind::create(KEY_Z, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_Z, Modifier::Command)) },
         Category::EDITOR_MODIFY, true
     });
     BindManager::get()->registerBindable({
         "robtop.geometry-dash/redo",
         "Redo",
         "Redo Last Action",
-        { Keybind::create(KEY_Z, Modifier::PlatformControl | Modifier::Shift) },
+        {
+            Keybind::create(KEY_Z, Modifier::Control | Modifier::Shift),
+            GEODE_MACOS(Keybind::create(KEY_Z, Modifier::Command | Modifier::Shift))
+        },
         Category::EDITOR_MODIFY, true
     });
     BindManager::get()->registerBindable({
@@ -409,21 +412,21 @@ $execute {
         "robtop.geometry-dash/copy",
         "Copy",
         "Copy Selected Objects",
-        { Keybind::create(KEY_C, Modifier::PlatformControl) },
+        { Keybind::create(KEY_C, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_C, Modifier::Command)) },
         Category::EDITOR_MODIFY, false
     });
     BindManager::get()->registerBindable({
         "robtop.geometry-dash/paste",
         "Paste",
         "Paste Selected Objects",
-        { Keybind::create(KEY_V, Modifier::PlatformControl) },
+        { Keybind::create(KEY_V, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_V, Modifier::Command)) },
         Category::EDITOR_MODIFY, true
     });
     BindManager::get()->registerBindable({
         "robtop.geometry-dash/copy-paste",
         "Copy + Paste",
         "Duplicate Selected Objects",
-        { Keybind::create(KEY_D, Modifier::PlatformControl) },
+        { Keybind::create(KEY_D, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_D, Modifier::Command)) },
         Category::EDITOR_MODIFY, true
     });
     BindManager::get()->registerBindable({
@@ -437,7 +440,7 @@ $execute {
         "robtop.geometry-dash/toggle-transform",
         "Transform",
         "Toggle Transform Control",
-        { Keybind::create(KEY_T, Modifier::PlatformControl) },
+        { Keybind::create(KEY_T, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_T, Modifier::Command)) },
         Category::EDITOR_UI, false
     });
     BindManager::get()->registerBindable({
@@ -472,7 +475,7 @@ $execute {
         "robtop.geometry-dash/playback-music",
         "Playback Music",
         "Start / Stop Playing the Level's Music",
-        { Keybind::create(KEY_Enter, Modifier::PlatformControl) },
+        { Keybind::create(KEY_Enter, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_Enter, Modifier::Command)) },
         Category::EDITOR_UI, false
     });
     BindManager::get()->registerBindable({
@@ -642,7 +645,10 @@ $execute {
             "Save Editor Position " + x,
             "Save the current editor camera position in the slot " + x + ". "
             "You can reload this slot back with Load Editor Position " + x,
-            { Keybind::create(static_cast<enumKeyCodes>(KEY_Zero + i), Modifier::PlatformControl) },
+            {
+                Keybind::create(static_cast<enumKeyCodes>(KEY_Zero + i), Modifier::Control),
+                GEODE_MACOS(Keybind::create(static_cast<enumKeyCodes>(KEY_Zero + i), Modifier::Command))
+            },
             Category::EDITOR_UI, false
         });
         BindManager::get()->registerBindable({

--- a/src/UILayer.cpp
+++ b/src/UILayer.cpp
@@ -399,7 +399,7 @@ $execute {
         "robtop.geometry-dash/full-restart-level",
         "Full restart level",
         "Restarts the level from the beginning (needs Quick Keys enabled)",
-        { Keybind::create(KEY_R, Modifier::Control) },
+        { Keybind::create(KEY_R, Modifier::Control), GEODE_MACOS(Keybind::create(KEY_R, Modifier::Command)) },
         Category::PLAY, false
     });
     BindManager::get()->registerBindable({

--- a/src/macos.mm
+++ b/src/macos.mm
@@ -1,9 +1,11 @@
 #include <Geode/Loader.hpp>
 #include <Geode/Utils.hpp>
 
-#if defined(GEODE_IS_MACOS)
+#ifdef GEODE_IS_MACOS
+#define CommentType CommentTypeDummy
 #import <Cocoa/Cocoa.h>
 #include <objc/runtime.h>
+#undef CommentType
 
 using namespace geode::prelude;
 


### PR DESCRIPTION
The modifier keys Control and Command have been separated in this mod. In the vanilla game, they go hand-and-hand, but with Custom Keybinds, they are made separate. I assume this is intentional, but I added alternatives for the vanilla binds that use Control anyway, so you have a choice to keep one or the other.

I assume there was a misconception that this Command/Control separation did not work. I personally think it works fine.