### PR TITLE
add controller detection support from launcher

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,6 +250,7 @@ public:
 		if (cocos2d::JniHelper::getStaticMethodInfo(info, "com/geode/launcher/utils/GeodeUtils", "getControllerCount", "()I")) {
 			int controllerCount = info.env->CallStaticIntMethod(info.classID, info.methodID);
 			controllerConnected = controllerCount > 0;
+			info.env->DeleteLocalRef(info.classID);
 		}
 #else
 		bool controllerConnected = PlatformToolbox::isControllerConnected();


### PR DESCRIPTION
requires [geode-sdk/android-launcher #47](https://github.com/geode-sdk/android-launcher/pull/47) to get merged first before this would work, but wont break on an unsupported launcher
(marked as draft until launcher pr is merged)